### PR TITLE
更新 README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Git for Windows.   国内直接从官网（`http://git-scm.com/download/win`）�
 
 找不到想要的版本？您可以访问 [淘宝 NPM 的 Git for Windows 索引页](https://npm.taobao.org/mirrors/git-for-windows/) 以下载更多版本。
 
-The latest (v2.25.0) version of Git for Windows, was released on 2020-1-13.
+The latest (v2.25.1) version of Git for Windows, was released on 2020-2-17.
 
 
-## v2.25.0 (2020-01-13)
+## v2.25.1 (2020-02-17)
 
-* 64-bit Git for Windows Setup : <https://npm.taobao.org/mirrors/git-for-windows/v2.25.0.windows.1/Git-2.25.0-64-bit.exe>
-* 64-bit Git for Windows Portable : <https://npm.taobao.org/mirrors/git-for-windows/v2.25.0.windows.1/PortableGit-2.25.0-64-bit.7z.exe>
+* 64-bit Git for Windows Setup : <https://cnpmjs.org/mirrors/git-for-windows/v2.25.1.windows.1/Git-2.25.1-64-bit.exe>
+* 64-bit Git for Windows Portable : <https://cnpmjs.org/mirrors/git-for-windows/v2.25.1.windows.1/PortableGit-2.25.1-64-bit.7z.exe>
 
 ## v2.24.1 (2019-12-06)
 


### PR DESCRIPTION
将 Git for Windows `v2.25.0` 的镜像下载链接替换为新发布的 `v2.25.1` 镜像下载链接。

> 注：不知为何，[淘宝 NPM 对应镜像](https://npm.taobao.org/mirrors/git-for-windows/)没有更新，这次更新使用的是 [CNPM 对应镜像](https://cnpmjs.org/mirrors/git-for-windows/)，下载速度也能过得去。